### PR TITLE
Fix for ternary operator condition.

### DIFF
--- a/source/com/redhat/ceylon/converter/JavaToCeylonConverter.java
+++ b/source/com/redhat/ceylon/converter/JavaToCeylonConverter.java
@@ -1437,7 +1437,7 @@ public class JavaToCeylonConverter implements Java8Listener {
 			}
 
 			if (ctx.getParent() instanceof ConditionalExpressionContext && ctx.getParent().getChildCount() > 1) {
-				bw.write(" then ");
+				bw.write(") then ");
 			}
 		} catch (IOException e) {
 
@@ -3326,7 +3326,7 @@ public class JavaToCeylonConverter implements Java8Listener {
 		// TODO add brackets if they are not present
 		if (ctx.getChildCount() > 1 && ctx.getChild(1).getText().equals("?")) {
 			try {
-				bw.write("if");
+				bw.write("if (");
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/testFiles/TestIf.java
+++ b/testFiles/TestIf.java
@@ -13,5 +13,7 @@ public class TestIf {
 		if(a % b == 0) {
 			a = b;
 		}
+
+		String c = a > b ? "gt" : "lt";
 	}
 }

--- a/testFiles/testIf.ceylon
+++ b/testFiles/testIf.ceylon
@@ -12,5 +12,6 @@ a=b + 1;
 if(a % b == 0){
 a=b;
 }
+variable String c = if (a > b) then "gt" else "lt";
 }
 }


### PR DESCRIPTION
This fixes missing parenthesis around the condition in the generated
if/then/else expression.

Example:
```java
String a = true ? "true" else "false;
```
Before:
```ceylon
variable String a = if true then "true" else "false";
```
After:
```ceylon
variable String a = if (true) then "true" else "false";
```