### PR TITLE
New option to transform getters to properties.

### DIFF
--- a/source/com/redhat/ceylon/converter/run.ceylon
+++ b/source/com/redhat/ceylon/converter/run.ceylon
@@ -13,7 +13,7 @@ import org.antlr.v4.runtime.tree {
 	ParseTreeWalker
 }
 
-shared void convert(String? file1, String? file2) {
+shared void convert(String? file1, String? file2, Boolean transformGetters = false) {
 	File f = File(file1);
 	
 	ANTLRInputStream input = ANTLRInputStream(FileInputStream(f));
@@ -26,7 +26,7 @@ shared void convert(String? file1, String? file2) {
 	
 	BufferedWriter bw = BufferedWriter(FileWriter(File(file2)));
 	
-	JavaToCeylonConverter converter = JavaToCeylonConverter(bw);
+	JavaToCeylonConverter converter = JavaToCeylonConverter(bw, transformGetters);
 	
 	// Java8Listener listener = new Java8Listener(this);
 	

--- a/source/test/com/redhat/ceylon/converter/testFiles.ceylon
+++ b/source/test/com/redhat/ceylon/converter/testFiles.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test {
 	test,
-	assertTrue
+    assertEquals
 }
 import com.redhat.ceylon.converter {
 	convert
@@ -16,10 +16,10 @@ import org.apache.commons.io {
 }
 
 shared void testFiles(String javaFileName, String ceylonFileName) {
-	convert(javaFileName + ".java", "testFiles/testConvertedFile.ceylon");
+	convert(javaFileName + ".java", "testFiles/testConvertedFile.ceylon", true);
 	File file1 = File(ceylonFileName + ".ceylon");
 	File file2 = File("testFiles/testConvertedFile.ceylon");
-	assertTrue(FileUtils.contentEquals(file1, file2));
+	assertEquals(FileUtils.readFileToString(file2), FileUtils.readFileToString(file1));
 }
 
 test
@@ -195,5 +195,13 @@ shared void testVariableDeclaration() {
 	String workingDir = System.getProperty("user.dir");
 	String javaFileName = workingDir + "/testFiles/TestVariableDeclaration";
 	String ceylonFileName = workingDir + "/testFiles/testVariableDeclaration";
+	testFiles(javaFileName, ceylonFileName);
+}
+
+test
+shared void testGetterSetter() {
+	String workingDir = System.getProperty("user.dir");
+	String javaFileName = workingDir + "/testFiles/TestGetterSetter";
+	String ceylonFileName = workingDir + "/testFiles/testGetterSetter";
 	testFiles(javaFileName, ceylonFileName);
 }

--- a/testFiles/TestGetterSetter.java
+++ b/testFiles/TestGetterSetter.java
@@ -1,0 +1,12 @@
+package com.redhat.ceylon.testFiles;
+
+public class TestMethod {
+	public void foo() {
+		String a = foo.method();
+		a = foo.isMethod();
+		foo.getMethod();
+		a = foo.getMethod(true);
+		foo.setMethod();
+		foo.setMethod(true);
+	}
+}

--- a/testFiles/testGetterSetter.ceylon
+++ b/testFiles/testGetterSetter.ceylon
@@ -1,0 +1,10 @@
+shared class TestMethod() {
+shared void foo(){
+variable String a = foo.method();
+a=foo.method;
+foo.method;
+a=foo.getMethod(true);
+foo.setMethod();
+foo.setMethod(true);
+}
+}


### PR DESCRIPTION
This PR allows transforming

```java
String a = foo.getBar();
```
into
```ceylon
variable String a = foo.bar;
```
to generate "more correct" code (I believe it should generate less false positives than it currently generates compilation errors).

This is an optional feature, it is disabled by default. The idea is to add an option in the IDE to let the user decide whether or not using properties instead of getters would help him.